### PR TITLE
clean up old launch configs after deploy

### DIFF
--- a/aws.yml
+++ b/aws.yml
@@ -130,3 +130,9 @@
         # Wait for this long to replace old instances
         wait_timeout: 300 # importing people can take ages
       when: not spot_price is defined
+
+
+    - name: Delete old unused on-demand Launch Configs
+      ec2_lc:
+        name: "wcivf_{{ aws_env }}-{{ old_lc_num }}"
+        state: absent


### PR DESCRIPTION
We had loads of old launch configs piled up in AWS (which I have deleted). This will delete the previous one each time we successfully deploy a fresh one.