### PR TITLE
update to latest ubuntu cloud image

### DIFF
--- a/packer
+++ b/packer
@@ -1,2 +1,2 @@
 #!/bin/bash -e
-/usr/bin/env packer build "$@" packer.json
+/usr/bin/env packer build -var-file=packer-vars.json "$@" packer.json

--- a/packer-vars.json
+++ b/packer-vars.json
@@ -1,0 +1,3 @@
+{
+  "ubuntu_ami_id": "ami-30c22657"
+}

--- a/packer.json
+++ b/packer.json
@@ -14,7 +14,7 @@
       "iam_instance_profile": "wcivf-packer-ami-builder",
       "instance_type":"m4.xlarge",
       "region":"{{user `build_region` }}",
-      "source_ami": "ami-d7aab2b3",
+      "source_ami": "ami-30c22657",
       "spot_price": "{{ user `max_spot_price`}}",
       "ssh_username": "ubuntu",
       "tags": {

--- a/packer.json
+++ b/packer.json
@@ -14,7 +14,7 @@
       "iam_instance_profile": "wcivf-packer-ami-builder",
       "instance_type":"m4.xlarge",
       "region":"{{user `build_region` }}",
-      "source_ami": "ami-30c22657",
+      "source_ami": "{{user `ubuntu_ami_id` }}",
       "spot_price": "{{ user `max_spot_price`}}",
       "ssh_username": "ubuntu",
       "tags": {


### PR DESCRIPTION
* update to latest ubuntu cloud image
* move ubuntu ami id to packer-vars.json

The second one of those might seem like a bit of a random thing to do, bit the reason I suggest this is because if we put it in the same location I have used in the https://github.com/DemocracyClub/polling_deploy and https://github.com/DemocracyClub/ee_deploy repos, I can more easily add this repo to the script I've set up to monitor Ubuntu cloud images. Then we can just ignore this and let a bot take care of updating this for us, like this https://github.com/DemocracyClub/ee_deploy/pull/3 and https://github.com/DemocracyClub/polling_deploy/pull/109

