### PR TITLE
Fix feedback form

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -49,7 +49,7 @@
     when: (application_git_repo.changed) or (application_config.changed)
 
   - name: Generate Django media.
-    shell: "PATH={{ project_root }}/env/bin/:$PATH {{ project_root }}/env/bin/python {{ project_root }}/code/manage.py collectstatic --noinput"
+    shell: "PATH={{ project_root }}/env/bin/:$PATH {{ project_root }}/env/bin/python {{ project_root }}/code/manage.py collectstatic --noinput --clear"
     when: (application_git_repo.changed) or (application_config.changed)
 
   - django_manage:


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/238

Finally managed to reproduce locally by running `./manage.py collectstatic --noinput` multiple times. Each time you run it, it will append `feedback/js/feedback_form.js` on to the end of `static/js/scripts.js` another time. Using the `--clear` option makes it overwrite rather than append.

Bit confused about how this is happening on deploy though. I don't understand how content would persist across image builds as we should start from a clean AMI every time. It seems like we should just create a clean static dir every time we build an image, but then looking at the commit history maybe you're not building a new image every time, or serving the static files from the controller? Dunno.. anyway, this should fix the feedback form.
