### PR TITLE
tag resources with app name

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -3,7 +3,8 @@
   "variables": {
     "build_region": "eu-west-2",
     "branch": "master",
-    "max_spot_price": "0.1"
+    "max_spot_price": "0.1",
+    "app_name": "wcivf"
   },
   "builders": [
     {
@@ -18,10 +19,20 @@
       "spot_price": "{{ user `max_spot_price`}}",
       "ssh_username": "ubuntu",
       "tags": {
+        "application": "{{user `app_name` }}",
         "build_date":"{{isotime}}"
       },
       "run_tags": {
+        "application": "{{user `app_name` }}",
         "Name": "packer-ami-build"
+      },
+      "run_volume_tags": {
+        "application": "{{user `app_name` }}",
+        "build_date":"{{isotime}}"
+      },
+      "snapshot_tags": {
+        "application": "{{user `app_name` }}",
+        "build_date":"{{isotime}}"
       }
     }
   ],


### PR DESCRIPTION
This change tags all AWS resources created by packer (images, instances, volumes and snapshots) with `application: wcivf`. This will make things easier to manage in the AWS console. I've already made an equivalent change to the EE scripts: https://github.com/DemocracyClub/ee_deploy/commit/c9892c580c859551f2b9390e0cede5156d56436f

We should probably do this for YNR as well, but given we're not using packer on that project the way we do that will be different.