### PR TITLE
use ELB health check

### DIFF
--- a/aws.yml
+++ b/aws.yml
@@ -124,7 +124,7 @@
           - Env: "{{ aws_env }}"
             Name: wcivf-asg
         desired_capacity: 1
-        health_check_type: EC2
+        health_check_type: ELB
         launch_config_name: "{{launchconfig.name}}"
         load_balancers: ["{{ elb_result.elb.name }}"]
         max_size: 10


### PR DESCRIPTION
Spotted this issue [over on EE](https://github.com/DemocracyClub/ee_deploy/commit/51acc922b8d7f76baf69f483db2468c8c755477c). It turned out to be the source of a problem I had been scratching my head over for some time.. then I remembered where I cribbed the code from.

I reckon [this whole song and dance](https://github.com/DemocracyClub/WhoCanIVoteFor/commit/0b2165692e1659d6c35b1e7169f2ff8d7d1a2bf4) has probably been bypassed this whole time because the ELB health check isn't the thing that determines whether to swap a new instance in to service.