### PR TITLE
add boto3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible==2.4.6.0
 boto
+boto3


### PR DESCRIPTION
boto3 needs to be in the virtual env or we error with

```
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "boto3 required for this module"}
```